### PR TITLE
Remove pandas dependency from backend

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,4 +2,3 @@ fastapi==0.115.0
 uvicorn[standard]==0.30.6
 numpy==2.1.1
 sentence-transformers==3.0.1
-pandas==2.2.2

--- a/backend/tools/normalize_kjv_csv.py
+++ b/backend/tools/normalize_kjv_csv.py
@@ -1,5 +1,7 @@
+"""Normalize raw KJV CSV into a standard format without pandas."""
+
+import csv
 import os
-import pandas as pd
 
 IN = os.path.join(os.path.dirname(__file__), "..", "data", "kjv.json.csv")
 OUT = os.path.join(os.path.dirname(__file__), "..", "data", "bible_full.csv")
@@ -27,35 +29,52 @@ def main():
     if not os.path.exists(IN):
         raise SystemExit(f"Input CSV not found: {IN}")
 
-    df = pd.read_csv(IN, sep=None, engine="python")
+    with open(IN, "r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        cols = reader.fieldnames or []
+        book_c = pick(cols, "book","book_name","Book","bookName","BookName","osis","book_id","bookId")
+        chap_c = pick(cols, "chapter","chapterNumber","chapter_nr","Chapter","chapter_num","ch")
+        vers_c = pick(cols, "verse","verseNumber","verse_nr","Verse","verse_num","v")
+        text_c = pick(cols, "text","verse_text","content","value","t","body","Text")
 
-    cols = df.columns
-    book_c = pick(cols, "book","book_name","Book","bookName","BookName","osis","book_id","bookId")
-    chap_c = pick(cols, "chapter","chapterNumber","chapter_nr","Chapter","chapter_num","ch")
-    vers_c = pick(cols, "verse","verseNumber","verse_nr","Verse","verse_num","v")
-    text_c = pick(cols, "text","verse_text","content","value","t","body","Text")
+        if book_c is None or chap_c is None or vers_c is None or text_c is None:
+            raise SystemExit(f"Could not detect columns. Found: {list(cols)}")
 
-    if book_c is None or chap_c is None or vers_c is None or text_c is None:
-        raise SystemExit(f"Could not detect columns. Found: {list(cols)}")
+        rows: list[dict[str, object]] = []
+        for row in reader:
+            book_raw = row.get(book_c, "")
+            try:
+                num = int(float(book_raw))
+                if 1 <= num <= 66:
+                    book = book_names[num-1]
+                else:
+                    book = f"Book{num}"
+            except (TypeError, ValueError):
+                book = str(book_raw).strip()
 
-    # Map book names if numeric or OSIS codes
-    book_series = df[book_c]
-    if pd.api.types.is_integer_dtype(book_series) or pd.api.types.is_float_dtype(book_series):
-        # 1..66 → names
-        df["book"] = book_series.astype(int).apply(lambda n: book_names[n-1] if 1 <= n <= 66 else f"Book{n}")
-    else:
-        # keep as string
-        df["book"] = book_series.astype(str)
+            def parse_int(val: object) -> int:
+                try:
+                    return int(float(val))
+                except (TypeError, ValueError):
+                    return 0
 
-    norm = pd.DataFrame({
-        "book": df["book"].astype(str),
-        "chapter": df[chap_c].astype(int),
-        "verse": df[vers_c].astype(int),
-        "text": df[text_c].astype(str).str.strip(),
-    })
+            chapter = parse_int(row.get(chap_c))
+            verse = parse_int(row.get(vers_c))
+            text = str(row.get(text_c, "")).strip()
 
-    norm.to_csv(OUT, index=False, encoding="utf-8")
-    print("Wrote", OUT, "rows:", len(norm))
+            rows.append({
+                "book": book,
+                "chapter": chapter,
+                "verse": verse,
+                "text": text,
+            })
+
+    with open(OUT, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["book", "chapter", "verse", "text"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print("Wrote", OUT, "rows:", len(rows))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- drop pandas from backend requirements
- rewrite KJV normalization tool to use Python's csv module

## Testing
- `pytest -q` *(fails: SyntaxError in backend/smoke_test.py)*
- `pytest backend/test_api.py -q`
- `python backend/tools/normalize_kjv_csv.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4dec3902c83328bf55be1597962c6