### PR TITLE
feat: allow disabling auto embed build

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -8,10 +8,11 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 EMB_PATH = os.path.join(DATA_DIR, 'verses.npy')
 META_PATH = os.path.join(DATA_DIR, 'meta.json')
 
-# Ensure artifacts exist; if not, build
-if not (os.path.exists(EMB_PATH) and os.path.exists(META_PATH)):
-	import subprocess, sys
-	subprocess.check_call([sys.executable, os.path.join(os.path.dirname(__file__), 'prepare_bible.py')])
+# Optionally auto-build artifacts
+AUTO_BUILD = os.getenv('AUTO_BUILD_EMBEDS', '1') != '0'
+if AUTO_BUILD and not (os.path.exists(EMB_PATH) and os.path.exists(META_PATH)):
+        import subprocess, sys
+        subprocess.check_call([sys.executable, os.path.join(os.path.dirname(__file__), 'prepare_bible.py')])
 
 # Load data
 emb = np.load(EMB_PATH)

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,12 @@ Backend (Render)
 - Build: `pip install -r requirements.txt && python prepare_bible.py`
 - Start: `uvicorn app:app --host 0.0.0.0 --port $PORT`
 
+Backend (Vercel)
+- Root: `backend/`
+- Build: `pip install -r requirements.txt && python prepare_bible.py`
+- Env: `AUTO_BUILD_EMBEDS=0`
+- Start: `uvicorn app:app --host 0.0.0.0 --port $PORT`
+
 Frontend (Vercel)
 - Root: `frontend/`
 - Env: `VITE_API_BASE=https://YOUR-BACKEND.onrender.com`


### PR DESCRIPTION
## Summary
- make embedding build optional via AUTO_BUILD_EMBEDS env var
- document pre-building embeddings and disabling auto build for Vercel

## Testing
- `python -m py_compile backend/app.py`
- `python backend/smoke_test.py` (fails: unicodeescape in docstring)
- `python - <<'PY'\nimport backend.app\nPY` (fails: ProxyError to huggingface)

------