### PR TITLE
feat: add optional reranker toggle

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -30,13 +30,14 @@ from sentence_transformers import SentenceTransformer
 EMB_MODEL = 'sentence-transformers/all-MiniLM-L6-v2'
 encoder = SentenceTransformer(EMB_MODEL)
 
-# Optional reranker
+# Optional reranker (disabled by default)
 RERANKER = None
-try:
-	from sentence_transformers import CrossEncoder
-	RERANKER = CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2')
-except Exception:
-	RERANKER = None
+if os.getenv('ENABLE_RERANKER', '').lower() in ('1', 'true', 'yes'):
+        try:
+                from sentence_transformers import CrossEncoder
+                RERANKER = CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2')
+        except Exception:
+                RERANKER = None
 
 # Minimal stopwords for quick keyword overlap
 STOP = set('''a an and are as at be but by for from has have i in is it its nor not of on or so that the their there these this to was were will with your you're you'''.split())

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,11 @@ pip install -r requirements.txt
 # Build embeddings once (first run will download models and take a few minutes)
 python prepare_bible.py
 
-# Start API
+# Start API (reranker disabled by default)
+uvicorn app:app --reload --port 8000
+
+# Enable Cross-Encoder reranker when memory allows
+$env:ENABLE_RERANKER=1
 uvicorn app:app --reload --port 8000
 ```
 
@@ -136,5 +140,5 @@ Notes
 -----
 
 - Works offline after first model download and embedding build.
-- Optional reranker improves precision; if loading fails (low RAM), it falls back automatically.
+- Optional reranker (Cross-Encoder) is disabled by default to save memory. Set `ENABLE_RERANKER=1` before starting the server to enable it when enough RAM is available; if loading fails, it falls back automatically.
 - To index paragraphs instead of verses, preprocess the CSV to paragraph rows and re-run `prepare_bible.py`.


### PR DESCRIPTION
## Summary
- gate CrossEncoder reranker behind `ENABLE_RERANKER` env var
- document how to enable the reranker when enough memory is available

## Testing
- `pytest --ignore=backend/smoke_test.py -q`


------